### PR TITLE
Fix lint issues, improve image handling, and restore mobile nav close prop

### DIFF
--- a/components/GitHubProjectsSlider.tsx
+++ b/components/GitHubProjectsSlider.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import Image from "next/image";
 
 type Repo = {
   id: number;
@@ -65,7 +66,7 @@ export default function GitHubProjectsSlider({
           throw new Error(`Failed to load repos: ${res.status} ${text}`);
         }
 
-        let data: Repo[] = await res.json();
+        let data = (await res.json()) as Repo[];
 
         // If fetching directly from GitHub, data includes all public repos.
         // Filter by topic on the client if requested (topics array might be missing for direct REST without preview headers).
@@ -80,8 +81,10 @@ export default function GitHubProjectsSlider({
             new Date(b.pushed_at).getTime() - new Date(a.pushed_at).getTime()
         );
         setRepos(data.slice(0, limit));
-      } catch (e: any) {
-        setError(e.message || "Something went wrong");
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error ? error.message : "Something went wrong";
+        setError(message);
       } finally {
         setLoading(false);
       }
@@ -152,12 +155,13 @@ export default function GitHubProjectsSlider({
               >
                 <article className="group h-full rounded-2xl border bg-white dark:bg-neutral-900 shadow-sm hover:shadow-md transition-shadow duration-200 overflow-hidden">
                   {/* Hero image: GitHub Open Graph preview */}
-                  <div className="h-40 w-full overflow-hidden">
-                    <img
+                  <div className="relative h-40 w-full overflow-hidden">
+                    <Image
                       src={`https://opengraph.githubassets.com/1/${repo.owner.login}/${repo.name}`}
                       alt={`${repo.name} preview`}
-                      className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
-                      loading="lazy"
+                      fill
+                      sizes="(min-width: 1024px) 460px, (min-width: 768px) 420px, (min-width: 640px) 360px, 88vw"
+                      className="object-cover transition-transform duration-300 group-hover:scale-[1.02]"
                     />
                   </div>
 

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -27,10 +27,10 @@ const Terminal: React.FC = () => {
       output: (
         <div className="space-y-2">
           <div className="text-[#00FF00]">
-            Welcome to my interactive 'AI powered' portfolio terminal!
+            Welcome to my interactive &apos;AI powered&apos; portfolio terminal!
           </div>
           <div className="text-[#00FF00]">
-            Type 'help' to see available commands.
+            Type &apos;help&apos; to see available commands.
           </div>
           <div className="text-[#00FF00] text-sm">
             Available commands: {Object.keys(commands).join(" | ")}
@@ -77,10 +77,10 @@ const Terminal: React.FC = () => {
         output: (
           <div className="space-y-2">
             <div className="text-[#00FF00]">
-              Welcome to my interactive 'AI powered' portfolio terminal!
+              Welcome to my interactive &apos;AI powered&apos; portfolio terminal!
             </div>
             <div className="text-[#00FF00]">
-              Type 'help' to see available commands.
+              Type &apos;help&apos; to see available commands.
             </div>
             <div className="text-[#00FF00] text-sm">
               Available commands: {Object.keys(commands).join(" | ")}
@@ -95,7 +95,7 @@ const Terminal: React.FC = () => {
     } else {
       output = (
         <div className="text-white">
-          Command not found: {cmd}. Type 'help' for available commands.
+          Command not found: {cmd}. Type &apos;help&apos; for available commands.
         </div>
       );
     }

--- a/components/commands.tsx
+++ b/components/commands.tsx
@@ -79,8 +79,8 @@ export const commands: { [key: string]: () => React.ReactNode } = {
       </div>
       <div className="space-y-2 text-white">
         <p>
-          Hi, I'm Rudraksh Tripathi, an Enthusiastic and results-driven software
-          developer. Passionate about building innovative solutions and
+          Hi, I&apos;m Rudraksh Tripathi, an Enthusiastic and results-driven
+          software developer. Passionate about building innovative solutions and
           leveraging technology to optimize processes.
         </p>
 
@@ -340,7 +340,7 @@ export const commands: { [key: string]: () => React.ReactNode } = {
           <div className="text-white text-sm space-y-1">
             <div>
               • Secured a place in the Top 10 among nationwide participants with
-              the project "Visionary-Spaces".
+              the project &quot;Visionary-Spaces&quot;.
             </div>
             <div>
               • Built a solution combining creativity and technology to design
@@ -523,7 +523,7 @@ export const commands: { [key: string]: () => React.ReactNode } = {
       <div className="space-y-3">
         <div className="p-4 bg-gray-900/50 rounded border border-green-400/20">
           <div className="text-white text-sm mb-3">
-            Let's connect and discuss opportunities!
+            Let&apos;s connect and discuss opportunities!
           </div>
           <div className="space-y-2 text-white text-sm">
             <div className="flex items-center">

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -7,7 +7,7 @@ export function Hero() {
       <h2 className="bg-clip-text  text-center bg-gradient-to-b from-neutral-900 to-neutral-700 dark:from-neutral-600 dark:to-white text-2xl md:text-4xl lg:text-7xl font-sans py-2 md:py-10 relative z-20 font-bold tracking-tight">
         Hi 👋
         <br />
-        I'm <Cover>Subhadeep Paul</Cover> 🧑‍💻
+        I&apos;m <Cover>Subhadeep Paul</Cover> 🧑‍💻
       </h2>
       <p className="max-w-xl mx-auto text-sm md:text-lg text-neutral-700 dark:text-neutral-400 text-center">
         Get the best advices from our experts, including expert artists,

--- a/components/ui/animated-tooltip.tsx
+++ b/components/ui/animated-tooltip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useRef } from "react";
+import Image from "next/image";
 import {
   motion,
   useTransform,
@@ -33,20 +34,26 @@ export const AnimatedTooltip = ({
     springConfig
   );
 
-  const handleMouseMove = (event: any) => {
+  const handleMouseMove = (
+    event: React.MouseEvent<HTMLImageElement>
+  ) => {
     if (animationFrameRef.current) {
       cancelAnimationFrame(animationFrameRef.current);
     }
 
+    const { currentTarget, nativeEvent } = event;
+    const { offsetWidth } = currentTarget;
+    const { offsetX } = nativeEvent;
+
     animationFrameRef.current = requestAnimationFrame(() => {
-      const halfWidth = event.target.offsetWidth / 2;
-      x.set(event.nativeEvent.offsetX - halfWidth);
+      const halfWidth = offsetWidth / 2;
+      x.set(offsetX - halfWidth);
     });
   };
 
   return (
     <>
-      {items.map((item, idx) => (
+      {items.map((item) => (
         <div
           className="group relative -mr-4"
           key={item.name}
@@ -84,10 +91,10 @@ export const AnimatedTooltip = ({
               </motion.div>
             )}
           </AnimatePresence>
-          <img
+          <Image
             onMouseMove={handleMouseMove}
-            height={100}
-            width={100}
+            height={56}
+            width={56}
             src={item.image}
             alt={item.name}
             className="relative !m-0 h-14 w-14 rounded-full border-2 border-white object-cover object-top !p-0 transition duration-500 group-hover:z-30 group-hover:scale-105"

--- a/components/ui/link-preview.tsx
+++ b/components/ui/link-preview.tsx
@@ -3,6 +3,7 @@ import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
 
 import { encode } from "qss";
 import React from "react";
+import Image from "next/image";
 import {
   AnimatePresence,
   motion,
@@ -67,8 +68,8 @@ export const LinkPreview = ({
 
   const translateX = useSpring(x, springConfig);
 
-  const handleMouseMove = (event: any) => {
-    const targetRect = event.target.getBoundingClientRect();
+  const handleMouseMove = (event: React.MouseEvent<HTMLElement>) => {
+    const targetRect = event.currentTarget.getBoundingClientRect();
     const eventOffsetX = event.clientX - targetRect.left;
     const offsetFromCenter = (eventOffsetX - targetRect.width / 2) / 2; // Reduce the effect to make it subtle
     x.set(offsetFromCenter);
@@ -78,11 +79,13 @@ export const LinkPreview = ({
     <>
       {isMounted ? (
         <div className="hidden">
-          <img
+          <Image
             src={src}
             width={width}
             height={height}
             alt="hidden image"
+            className="hidden"
+            priority
           />
         </div>
       ) : null}
@@ -133,7 +136,7 @@ export const LinkPreview = ({
                   className="block p-1 bg-white border-2 border-transparent shadow rounded-xl hover:border-neutral-200 dark:hover:border-neutral-800"
                   style={{ fontSize: 0 }}
                 >
-                  <img
+                  <Image
                     src={isStatic ? imageSrc : src}
                     width={width}
                     height={height}

--- a/components/ui/resizable-navbar.tsx
+++ b/components/ui/resizable-navbar.tsx
@@ -8,7 +8,7 @@ import {
   useMotionValueEvent,
 } from "motion/react";
 
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Image from "next/image";
 
 interface NavbarProps {
@@ -47,7 +47,7 @@ interface MobileNavMenuProps {
   children: React.ReactNode;
   className?: string;
   isOpen: boolean;
-  // onClose: () => void;
+  onClose?: () => void;
 }
 
 export const Navbar = ({ children, className }: NavbarProps) => {
@@ -199,24 +199,60 @@ export const MobileNavMenu = ({
   children,
   className,
   isOpen,
-}: // onClose,
-MobileNavMenuProps) => {
+  onClose,
+}: MobileNavMenuProps) => {
+  useEffect(() => {
+    if (!isOpen || !onClose) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          className={cn(
-            "absolute inset-x-0 top-16 z-50 flex w-full flex-col items-start justify-start gap-4 rounded-lg bg-white px-4 py-8 shadow-[0_0_24px_rgba(34,_42,_53,_0.06),_0_1px_1px_rgba(0,_0,_0,_0.05),_0_0_0_1px_rgba(34,_42,_53,_0.04),_0_0_4px_rgba(34,_42,_53,_0.08),_0_16px_68px_rgba(47,_48,_55,_0.05),_0_1px_0_rgba(255,_255,_255,_0.1)_inset] dark:bg-neutral-950",
-            className
-          )}
-        >
-          {children}
-        </motion.div>
-      )}
-    </AnimatePresence>
+    <>
+      <AnimatePresence>
+        {isOpen && onClose && (
+          <motion.button
+            key="mobile-nav-overlay"
+            type="button"
+            aria-label="Close menu"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 0.4 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm lg:hidden"
+            onClick={onClose}
+          />
+        )}
+      </AnimatePresence>
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            key="mobile-nav-menu"
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.1 }}
+            className={cn(
+              "absolute inset-x-0 top-16 z-50 flex w-full flex-col items-start justify-start gap-4 rounded-lg bg-white px-4 py-8 shadow-[0_0_24px_rgba(34,_42,_53,_0.06),_0_1px_1px_rgba(0,_0,_0,_0.05),_0_0_0_1px_rgba(34,_42,_53,_0.04),_0_0_4px_rgba(34,_42,_53,_0.08),_0_16px_68px_rgba(47,_48,_55,_0.05),_0_1px_0_rgba(255,_255,_255,_0.1)_inset] dark:bg-neutral-950",
+              className
+            )}
+          >
+            {children}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
   );
 };
 
@@ -235,7 +271,6 @@ export const MobileNavToggle = ({
 };
 
 export const NavbarLogo = () => {
-  // eslint-disable-next-line @next/next/no-img-element
   return (
     <a
       href="#"

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,7 @@ const nextConfig: NextConfig = {
   images: {
     domains: [
       "api.microlink.io", // Microlink Image Preview
+      "opengraph.githubassets.com", // GitHub Open Graph previews
     ],
   },
   eslint: {


### PR DESCRIPTION
## Summary
- add GitHub API typings and safer error handling for the projects API route
- replace raw <img> usage with next/image and typed mouse handlers across UI components
- escape unescaped characters in terminal-related copy to satisfy lint rules and extend image domains
- allow the resizable navbar mobile menu to accept an onClose callback and close via backdrop or Escape key for type-safe usage from components/navbar.tsx

## Testing
- `pnpm run lint`
- `pnpm run build` *(fails: Turbopack cannot download Google Fonts in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68c8617c10988333891e0f7228dfb693