### PR TITLE
Improve RAG API error handling

### DIFF
--- a/app/api/rag/route.ts
+++ b/app/api/rag/route.ts
@@ -22,9 +22,13 @@ CONTEXT:
 Answer:`);
 
 async function getRetriever() {
+  const chromaApiKey = process.env.CHROMA_API_KEY;
+  if (!chromaApiKey) {
+    throw new Error("CHROMA_API_KEY environment variable is not set.");
+  }
   const embeddings = new OpenAIEmbeddings({ model: "text-embedding-3-small" });
   const client = new CloudClient({
-    apiKey: process.env.CHROMA_API_KEY!,
+    apiKey: chromaApiKey,
   });
   const store = new Chroma(embeddings, {
     collectionName: "subhadeep_rag",
@@ -34,35 +38,73 @@ async function getRetriever() {
 }
 
 export async function POST(req: NextRequest) {
-  const { question } = await req.json();
-  const retriever = await getRetriever();
-  const llm = new ChatOpenAI({
-    model: "gpt-4o-mini",
-    temperature: 0.2,
-    streaming: true,
-  });
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return textResponse("Invalid JSON body.", 400);
+  }
 
-  const chain = RunnableSequence.from([
-    {
-      context: retriever.pipe((docs) =>
-        docs.map((d) => `• ${d.pageContent}`).join("\n\n")
-      ),
-      question: new RunnablePassthrough(),
-    },
-    prompt,
-    llm,
-  ]);
+  const question =
+    typeof body === "object" && body !== null
+      ? (body as Record<string, unknown>).question
+      : undefined;
 
-  const stream = await chain.stream({ question });
-  const enc = new TextEncoder();
-  return new Response(
-    new ReadableStream({
-      async pull(controller) {
-        for await (const chunk of stream)
-          controller.enqueue(enc.encode(String(chunk)));
-        controller.close();
+  if (typeof question !== "string" || !question.trim()) {
+    return textResponse(
+      "Request body must include a non-empty `question` string.",
+      400
+    );
+  }
+
+  try {
+    const retriever = await getRetriever();
+    const llm = new ChatOpenAI({
+      model: "gpt-4o-mini",
+      temperature: 0.2,
+      streaming: true,
+    });
+
+    const chain = RunnableSequence.from([
+      {
+        context: retriever.pipe((docs) =>
+          docs.map((d) => `• ${d.pageContent}`).join("\n\n")
+        ),
+        question: new RunnablePassthrough(),
       },
-    }),
-    { headers: { "Content-Type": "text/plain; charset=utf-8" } }
-  );
+      prompt,
+      llm,
+    ]);
+
+    const stream = await chain.stream({ question: question.trim() });
+    const enc = new TextEncoder();
+    return new Response(
+      new ReadableStream({
+        async pull(controller) {
+          try {
+            for await (const chunk of stream)
+              controller.enqueue(enc.encode(String(chunk)));
+            controller.close();
+          } catch (err) {
+            controller.error(err);
+          }
+        },
+      }),
+      { headers: { "Content-Type": "text/plain; charset=utf-8" } }
+    );
+  } catch (err) {
+    console.error("RAG route error:", err);
+    const message =
+      err instanceof Error
+        ? err.message
+        : "Unknown error while running the RAG pipeline.";
+    return textResponse(`RAG pipeline error: ${message}`);
+  }
+}
+
+function textResponse(message: string, status = 500) {
+  return new Response(message, {
+    status,
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
 }


### PR DESCRIPTION
## Summary
- validate the RAG route configuration and request payload before running the chain
- wrap the pipeline in error handling that surfaces informative response messages
- guard the streaming loop so downstream failures are surfaced cleanly

## Testing
- pnpm lint *(fails: pre-existing lint errors in components/navbar.tsx, components/slider.tsx, components/ui/cover.tsx, components/ui/link-preview.tsx, scripts/ingest.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e3b32f808333b307bb00d2e0fcbb